### PR TITLE
Fix search route parameter in PatientsController

### DIFF
--- a/PatientRecordSystem/Controllers/PatientsController.cs
+++ b/PatientRecordSystem/Controllers/PatientsController.cs
@@ -38,10 +38,10 @@ namespace PatientRecordSystem.Controllers
             return Ok(await _patientService.GetPatientReport(id));
         }
 
-        [HttpGet("Search/{id}")]
-        public async Task<ActionResult<IEnumerable<KeyValuePairResource>>> Search(string prfix)
+        [HttpGet("Search/{prefix}")]
+        public async Task<ActionResult<IEnumerable<KeyValuePairResource>>> Search(string prefix)
         {
-            var list = await _patientService.Search(prfix, 50);
+            var list = await _patientService.Search(prefix, 50);
             var data = _mapper.Map<IEnumerable<Patient>, IEnumerable<KeyValuePairResource>>(list);
             return Ok(data);
         }

--- a/PatientRecordSystem/Domain/Repositories/IPatientRepository.cs
+++ b/PatientRecordSystem/Domain/Repositories/IPatientRepository.cs
@@ -13,7 +13,7 @@ namespace PatientRecordSystem.Domain.Repositories
     {
         Task<PatientReportResource> GetPatientReport(int id);
 
-        Task<IEnumerable<Patient>> Search(string prfix, int size);
+        Task<IEnumerable<Patient>> Search(string prefix, int size);
 
         Task<PagedList<PatientResource>> ListAsync(QueryStringParameters queryString, Dictionary<string, Expression<Func<PatientResource, object>>> columnsMap);
 

--- a/PatientRecordSystem/Domain/Services/IPatientService.cs
+++ b/PatientRecordSystem/Domain/Services/IPatientService.cs
@@ -14,7 +14,7 @@ namespace PatientRecordSystem.Domain.Services
     {
         Task<PatientResponse> GetById(int id);
 
-        Task<IEnumerable<Patient>> Search(string prfix, int size);
+        Task<IEnumerable<Patient>> Search(string prefix, int size);
 
         Task<PatientReportResource> GetPatientReport(int id);
 

--- a/PatientRecordSystem/Persistence/Repositories/PatientRepository.cs
+++ b/PatientRecordSystem/Persistence/Repositories/PatientRepository.cs
@@ -24,9 +24,9 @@ namespace PatientRecordSystem.Persistence.Repositories
             return await _context.Patients.Include(x => x.MetaData).SingleOrDefaultAsync(x => x.Id == id);
         }
 
-        public async Task<IEnumerable<Patient>> Search(string prfix, int size)
+        public async Task<IEnumerable<Patient>> Search(string prefix, int size)
         {
-            return await _context.Patients.Where(x => x.PatientName.StartsWith(prfix)).OrderBy(x => x.PatientName).Take(size).ToListAsync();
+            return await _context.Patients.Where(x => x.PatientName.StartsWith(prefix)).OrderBy(x => x.PatientName).Take(size).ToListAsync();
         }
 
         public async Task<PatientReportResource> GetPatientReport(int id)

--- a/PatientRecordSystem/Services/PatientService.cs
+++ b/PatientRecordSystem/Services/PatientService.cs
@@ -36,9 +36,9 @@ namespace PatientRecordSystem.Services
             return new PatientResponse(patient);
         }
 
-        public async Task<IEnumerable<Patient>> Search(string prfix, int size)
+        public async Task<IEnumerable<Patient>> Search(string prefix, int size)
         {
-            return await _patientRepository.Search(prfix, size);
+            return await _patientRepository.Search(prefix, size);
         }
 
         public async Task<PagedList<PatientResource>> ListAsync(QueryStringParameters queryString, Dictionary<string, Expression<Func<PatientResource, object>>> columnsMap)


### PR DESCRIPTION
## Summary
- align route parameter names in `PatientsController.Search`
- rename `prfix` to `prefix` across patient search code

## Testing
- `dotnet test PatientRecordSystem/PatientRecordSystem.csproj -v q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847ee007bac8327b7caf7fd2e7c684b